### PR TITLE
Modify Redirect path in BeforeAction

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  #def authenticate_drinker!
-  #  session[:drinker_return_to] = env['PATH_INFO']
-  #  redirect_to drinker_facebook_omniauth_authorize_path unless drinker_signed_in?
-  #end
+  def authenticate_drinker!
+    session[:drinker_return_to] = env['PATH_INFO']
+    redirect_to login_path unless drinker_signed_in?
+  end
 end

--- a/app/controllers/drinkers_controller.rb
+++ b/app/controllers/drinkers_controller.rb
@@ -1,12 +1,12 @@
 class DrinkersController < ApplicationController
-  before_action :authenticate_drinker!
+  before_action :authenticate_drinker!, only:[:edit, :show, :update, :redirector ]
 
   def redirector
     redirect_to '/drinker/auth/facebook?passcode='+params[:passcode]
   end
 
   def login
-    
+
   end
 
   def edit


### PR DESCRIPTION
ログインしているかどうかのBeforeActionで
ログインしていなかった場合に遷移する場所をログインとサインアップを行う画面に変更しました。
（ハッカソンの最終発表で起きたバグが解決するはずです）