### PR TITLE
ヘッダとフッタを表示するためのコードを追加

### DIFF
--- a/app/assets/stylesheets/shared/_footer.scss
+++ b/app/assets/stylesheets/shared/_footer.scss
@@ -27,5 +27,9 @@ $footer-height: 80px;
 
 .l_contents {
   padding-bottom: $footer-height;
+
+  &_no-footer#{&} {
+    padding-bottom: 0
+  }
 }
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,12 @@
   </head>
 
   <body>
-    <%= yield %>
+    <div class="l_wrap">
+      <%= render :partial => "shared/header" %>
+      <div class="l_contents l_contents_no-footer">
+        <%= yield %>
+      </div>
+      <%= render :partial => "shared/footer" %>
+    </div>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,8 +1,8 @@
 ﻿<!DOCTYPE html>
 <html lang="ja">
   <head>
-    <title>Hiyaoroshigo</title>
     <meta charset="UTF-8">
+    <title>松江トランキーロ</title>
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,8 @@
 ﻿<!DOCTYPE html>
-<html>
+<html lang="ja">
   <head>
     <title>Hiyaoroshigo</title>
+    <meta charset="UTF-8">
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>


### PR DESCRIPTION
# 背景
#54 での変更にcommit漏れしたファイルがあった(申し訳ないです)

# やったこと
* commit漏れしていたものを追記
* フッタを表示しない時に、コンテンツをラップする要素につけるクラスを定義
* HTMLの言語と文字コードについて設定されていなかったので追記
    * 他にも普通のサイトなら書くSEO対策用のタグはあるが、参加者しかアクセスしないサイトなので書かなかった
* タイトルが「Hiyaoroshigo」になっていて適当感があったので、羽角さんに伺ってタイトル要素の内容を「松江トランキーロ」に変更