### PR TITLE
Hotfix save fullname

### DIFF
--- a/app/models/drinker.rb
+++ b/app/models/drinker.rb
@@ -7,15 +7,16 @@ class Drinker < ApplicationRecord
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :omniauthable
-  
+
   # TODO: パスフレーズを受け取ってticketレコードを紐付ける処理を追加する
   def self.find_for_facebook_oauth(auth,params)
     drinker = Drinker.where(provider: auth.provider, uid: auth.uid).first
 
     unless drinker
       if Ticket.find_by(params[:passcode]).used?
-        drinker = Drinker.new(name:     auth.extra.raw_info.name,
-                              provider: auth.provider,                               
+        drinker = Drinker.new(full_name:     auth.extra.raw_info.name,
+                              name:     auth.extra.raw_info.name,
+                              provider: auth.provider,
                               uid:      auth.uid,
                               email:    auth.info.email,
                               token:    auth.credentials.token,

--- a/app/models/drinker.rb
+++ b/app/models/drinker.rb
@@ -15,7 +15,6 @@ class Drinker < ApplicationRecord
     unless drinker
       if Ticket.find_by(params[:passcode]).used?
         drinker = Drinker.new(full_name:     auth.extra.raw_info.name,
-                              name:     auth.extra.raw_info.name,
                               provider: auth.provider,
                               uid:      auth.uid,
                               email:    auth.info.email,


### PR DESCRIPTION
Facebook認証で取ってきた名前はDrinker#fullnameに保存されるように変更しました。
nameはnilが初期値に入ります。