### PR TITLE
投票モーダルの閉じるボタンのスタイル崩れを修正

### DIFF
--- a/app/assets/stylesheets/drinkings.scss
+++ b/app/assets/stylesheets/drinkings.scss
@@ -36,6 +36,15 @@ body .ui-widget-overlay {
     border-radius: 100%;
     border: 1px solid #d0d0d0;
 
+    .fa {
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      line-height: 10vw;
+    }
+
     #{&}button {
       font-size: 6vw;
     }


### PR DESCRIPTION
後ろの丸が楕円になってるように見えてまだ若干おかしい気がします……
いまいち原因が分かっていない

before | after
---- | ----
![simulator screen shot 2016 09 17 16 58 56](https://cloud.githubusercontent.com/assets/19262148/18606921/36e3385a-7cf8-11e6-803f-cf7e6d3eab96.png) | ![simulator screen shot 2016 09 17 16 56 08](https://cloud.githubusercontent.com/assets/19262148/18606920/3697340a-7cf8-11e6-965a-d4ec9abc1f10.png)
